### PR TITLE
Handle null returned from parseFrontMatterTags

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ export default class ObsidianQueryLanguagePlugin extends Plugin {
 		if (metadata) {
 			// Get the tags from the frontmatter
 			if (metadata?.frontmatter?.tags) {
-				tags = parseFrontMatterTags(metadata.frontmatter)
+				tags = parseFrontMatterTags(metadata.frontmatter) ?? []
 			} 
 			// Also add the tags from the metadata object (these are present in document itself)
 			if (metadata?.tags) {


### PR DESCRIPTION
Issue #24 describes when installing obsidian-query-language that results in users getting the error

> `Index not build yet... (check back after opening another note!)`

For me, I saw the following error in the console:

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'concat')
    at ObsidianQueryLanguagePlugin.eval (plugin:obsidian-query-language:27276:37)
    at step (plugin:obsidian-query-language:79:23)
    at Object.eval [as next] (plugin:obsidian-query-language:60:53)
    at eval (plugin:obsidian-query-language:53:71)
    at new Promise (<anonymous>)
    at __awaiter (plugin:obsidian-query-language:49:12)
    at ObsidianQueryLanguagePlugin.parseTags (plugin:obsidian-query-language:27265:16)
    at ObsidianQueryLanguagePlugin.eval (plugin:obsidian-query-language:27242:51)
    at step (plugin:obsidian-query-language:79:23)
    at Object.eval [as next] (plugin:obsidian-query-language:60:53)
```

Which links back to line 100 of this snippet: https://github.com/jplattel/obsidian-query-language/blob/d6205bdd381598e897ec698c116c196be38b5a1d/src/main.ts#L91-L104

Here on line 100, `tags` can sometimes be `null` because `parseFrontMatterTags` can sometimes return `null` (see the [obsidian-api](https://github.com/obsidianmd/obsidian-api/blob/6b2138aa28fb6d6f58f78e6fabec02186fdc0f82/obsidian.d.ts#L2518-L2521); I didn't see any obvious reason why it might sometimes do that). So this change just sets it to an empty list when that happens.

(This pull request addresses that root cause, but I don't know if everyone would be experiencing the same root cause.)